### PR TITLE
bityuan升级storedb，开启exec_local，默认主链升级，不需要开启，只有在平行链升级时需要开启

### DIFF
--- a/bityuan.lite.toml
+++ b/bityuan.lite.toml
@@ -28,6 +28,8 @@ dbCache=64
 batchsync=false
 isRecordBlockSequence=false
 enableTxQuickIndex=false
+# 升级storedb是否重新执行localdb，bityuan主链升级不需要开启，平行链升级需要开启
+enableReExecLocal=false
 
 [p2p]
 seeds=[]

--- a/bityuan.toml
+++ b/bityuan.toml
@@ -28,6 +28,8 @@ dbCache=64
 batchsync=false
 isRecordBlockSequence=false
 enableTxQuickIndex=true
+# 升级storedb是否重新执行localdb，bityuan主链升级不需要开启，平行链升级需要开启
+enableReExecLocal=false
 
 [p2p]
 port=13802


### PR DESCRIPTION
需要等前面4.25更新合并到bityuan，再将在配置更新合并进去