### PR TITLE
add by hyb for enableBestBlockCmp

### DIFF
--- a/bityuan.go
+++ b/bityuan.go
@@ -45,6 +45,7 @@ minerstart=true
 genesisBlockTime=1514533394
 genesis="14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
 minerExecs=["ticket", "autonomy"]
+enableBestBlockCmp=true
 
 [mver.consensus]
 fundKeyAddr = "1JmFaA6unrCFYEWPGRi7uuXY1KthTJxJEP"


### PR DESCRIPTION
开启最优区块的辅助比较功能。
ticket共识时，当同一个高度有多个区块时，开启最优区块的辅助比较功能，我们选择出难度系数最难的区块作为最优区块。及时让全网基于最优区块挖矿，减少在侧链上挖矿