### PR TITLE
update dht config

### DIFF
--- a/bityuan.go
+++ b/bityuan.go
@@ -2,7 +2,7 @@ package main
 
 var bityuan = `
 TestNet=false
-version="6.4.1"
+version="6.4.2"
 CoinSymbol="bty"
 
 [blockchain]
@@ -23,7 +23,8 @@ driver="leveldb"
 serverStart=true
 
 [p2p.sub.dht]
-seeds=["/ip4/116.62.14.25/tcp/13803/p2p/16Uiu2HAmTLe2UuhiEiXkMBzbMsEUSJSqRCrc2rDJou855amo1JGD",
+#bootstraps是内置不能修改的引导节点
+bootstraps=["/ip4/116.62.14.25/tcp/13803/p2p/16Uiu2HAmTLe2UuhiEiXkMBzbMsEUSJSqRCrc2rDJou855amo1JGD",
 "/ip4/39.106.166.159/tcp/13803/p2p/16Uiu2HAmM7iiHwerHR63CpG71sd2Y3jmC6QrPuAT1hRPWL9wx4eB",
 "/ip4/47.106.114.93/tcp/13803/p2p/16Uiu2HAmAvHCoV1i9U3MHorQGZNRUhms1FXpd57g12fpovg3owRS",
 "/ip4/120.76.100.165/tcp/13803/p2p/16Uiu2HAmGoQ8Sp9Tk42ftV6TjrMaSjSNuYJ6xNKVoAw18AcNJ6dy",

--- a/bityuan.toml
+++ b/bityuan.toml
@@ -50,7 +50,11 @@ useGithub=true
 innerBounds=300
 
 [p2p.sub.dht]
+#可以自定义设置连接节点
+seeds=[]
 port=13803
+#dht 版本还不稳定，暂时限定较小的连接数
+maxConnnectNum=50
 
 
 [rpc]


### PR DESCRIPTION
fix #92 
* 增加bootstraps配置，替换seeds配置，seeds支持外部配置节点

* dht新版本不太稳定，暂时限定较小连接数50，减小节点负载，内部默认是100

* 更新版本号到6.4.2