### PR TITLE
update broadcast config

### DIFF
--- a/bityuan.toml
+++ b/bityuan.toml
@@ -58,13 +58,8 @@ innerBounds=300
 seeds=[]
 port=13803
 maxConnectNum=40
-#区块轻广播最低区块大小，1k
-minLtBlockSize=100
 # 是否配置为全节点模式，全节点保存所有分片数据，种子节点应配置为true
 isFullNode=false
-# 兼容老版本广播节点数，目前比特元网络已基本全面升级6.5.3，新版本不再支持广播发送至老版本
-# 设为1为屏蔽默认设置5
-maxBroadcastPeers=1
 
 [p2p.sub.dht.pubsub]
 gossipSubDlo=7
@@ -73,6 +68,14 @@ gossipSubDhi=20
 gossipSubHeartbeatInterval=900
 gossipSubHistoryGossip=2
 gossipSubHistoryLength=7
+
+[p2p.sub.dht.broadcast]
+# 区块哈希广播最小大小 100KB
+minLtBlockSize=100
+#关闭交易批量广播功能, 后续全网升级后再开启
+disableBatchTx=true
+#关闭轻广播方案, 后续全网升级后再开启
+disableLtBlock=true
 
 
 [rpc]


### PR DESCRIPTION

1. 后续版本升级时, 适配底层框架广播模块调整( 33cn/chain33#1169 ), 需要更新的广播配置更新

2. 广播协议升级, 比特元网络需要两次升级, 首先是代码更新,进行功能支持, 全网升级后再进行功能开启升级