### PR TITLE
Update chain33

### DIFF
--- a/bityuan-fullnode.toml
+++ b/bityuan-fullnode.toml
@@ -81,6 +81,14 @@ enableTLS=false
 certFile="cert.pem"
 keyFile="key.pem"
 
+[rpc.sub.eth]
+enable=true
+httpAddr="localhost:8546"
+httpApi=["eth","web3","personal","admin","net"]
+# websocket 绑定地址
+wsAddr="localhost:8547"
+wsApi=["eth","web3","personal","admin","net"]
+
 [mempool]
 maxTxNumPerAccount=100
 

--- a/bityuan.go
+++ b/bityuan.go
@@ -183,6 +183,10 @@ signType="secp256k1"
 
 [exec]
 
+[exec.sub.coins]
+#允许evm执行器操作coins
+friendExecer=["evm"]
+
 [exec.sub.token]
 #配置一个空值，防止配置文件被覆盖
 tokenApprs = []
@@ -292,6 +296,12 @@ itemWaitBlockNumber=40000
 
 [exec.sub.evm]
 addressDriver="eth"
+#免交易费模式联盟链允许的最大gas，该配置只对不收取交易费部署方式有效，其他部署方式下该配置不会产生作用
+##当前最大为200万
+evmGasLimit=8000000
+ethMapFromExecutor="coins"
+#title的币种名称
+ethMapFromSymbol="bty" 
 
 #系统中所有的fork,默认用chain33的测试网络的
 #但是我们可以替换

--- a/bityuan.go
+++ b/bityuan.go
@@ -332,8 +332,13 @@ ForkEVMFrozen=19900000
 ForkEVMTxGroup=19900000
 ForkEVMKVHash=19900000
 
+
+[fork.sub.none]
+ForkUseTimeDelay=22650000
+
 [fork.sub.coins]
 Enable=0
+ForkFriendExecer=22650000
 
 [fork.sub.ticket]
 Enable=0

--- a/bityuan.go
+++ b/bityuan.go
@@ -296,9 +296,6 @@ itemWaitBlockNumber=40000
 
 [exec.sub.evm]
 addressDriver="eth"
-#免交易费模式联盟链允许的最大gas，该配置只对不收取交易费部署方式有效，其他部署方式下该配置不会产生作用
-##当前最大为200万
-evmGasLimit=8000000
 ethMapFromExecutor="coins"
 #title的币种名称
 ethMapFromSymbol="bty" 

--- a/bityuan.toml
+++ b/bityuan.toml
@@ -80,6 +80,14 @@ enableTLS=false
 certFile="cert.pem"
 keyFile="key.pem"
 
+[rpc.sub.eth]
+enable=true
+httpAddr="localhost:8546"
+httpApi=["eth","web3","personal","admin","net"]
+# websocket 绑定地址
+wsAddr="localhost:8547"
+wsApi=["eth","web3","personal","admin","net"]
+
 [mempool]
 maxTxNumPerAccount=100
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/bityuan/bityuan
 go 1.16
 
 require (
-	github.com/33cn/chain33 v1.67.3
-	github.com/33cn/plugin v1.67.3
+	github.com/33cn/chain33 v1.67.4-0.20220817080150-b88527a2672f
+	github.com/33cn/plugin v1.67.4-0.20220727093549-3eb13903a594
 )

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,13 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/33cn/chain33 v1.67.3 h1:h4VJP3t203n2owUMkjvyC88AM/gpPnu1vIOJ0+WG8DM=
 github.com/33cn/chain33 v1.67.3/go.mod h1:rOabIpP0KWiehXmX6ShOrAveTUvdoQvjUkUePdwk/oQ=
+github.com/33cn/chain33 v1.67.4-0.20220722090050-f04f8bab7f42/go.mod h1:uKMKtco0RFJYqJ45wlsTGt0kxQnj2CdFNZTCXLVEIaQ=
+github.com/33cn/chain33 v1.67.4-0.20220817080150-b88527a2672f h1:Je5TMUrq1aUmMv3l8/lnzOfjgii8heG5g2HB/3RHmQg=
+github.com/33cn/chain33 v1.67.4-0.20220817080150-b88527a2672f/go.mod h1:uKMKtco0RFJYqJ45wlsTGt0kxQnj2CdFNZTCXLVEIaQ=
 github.com/33cn/plugin v1.67.3 h1:QsKhM3Uqtx/RHZOAJVByHcCy2P1nGtADHh6jUQS92XY=
 github.com/33cn/plugin v1.67.3/go.mod h1:uvlJy8zyxsn2TsYf5+8ojFEIU3BQyeyyJ5VXtnBuIes=
+github.com/33cn/plugin v1.67.4-0.20220727093549-3eb13903a594 h1:GhyBVWFVwGbZw4haEwW/Y545EHBKoMoRJsaN/5F5mJ0=
+github.com/33cn/plugin v1.67.4-0.20220727093549-3eb13903a594/go.mod h1:qZkHYj53zYxHeA5xNymnhsy2Lp0tc9JT30BuqjNJbkk=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=


### PR DESCRIPTION

更新最新 chain33 及 plugin 依赖

* 支持钱包找回脚本延时类型区块时间, 对应fork高度 22650000
* 进一步兼容ethereum web3生态, 对应fork高度 22650000