### PR TITLE
[[FIX]] build and CI improvements only, no functional changes

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -28,17 +28,23 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install zig
+        run: |
+          curl -sSfL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | sudo tar -xJ --strip-components=1 -C /usr/local
+          sudo ln -sf /usr/local/zig /usr/local/bin/zig
+          zig version
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
-            semantic-release-replace-plugin
-            @semantic-release/exec
-            @semantic-release/changelog
-            @semantic-release/git
+            conventional-changelog-jshint@5.2.0
+            semantic-release-replace-plugin@1.2.7
+            @semantic-release/exec@6
+            @semantic-release/changelog@6
+            @semantic-release/git@10
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 on: [push,pull_request]
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_fmt:
     runs-on: ubuntu-22.04
@@ -9,6 +13,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: Intsall Golangci-lint
         run: |
@@ -19,10 +24,10 @@ jobs:
           echo $GOPATH
           echo $PATH
           go install golang.org/x/tools/cmd/goimports@v0.13.0
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
-          # install shfmt binary directly to avoid Go version compatibility issues
+          # install binary tools directly to avoid Go version compatibility issues
+          curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-linux-amd64.tar.gz | tar -xz --strip-components=1 -C /usr/local/bin
           curl -sSfL https://github.com/mvdan/sh/releases/download/v2.6.3/shfmt_v2.6.3_linux_amd64 -o /usr/local/bin/shfmt
-          chmod +x /usr/local/bin/shfmt
+          chmod +x /usr/local/bin/shfmt /usr/local/bin/golangci-lint
 
       - name: Lint
         run: |
@@ -38,6 +43,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          cache: true
       - name: set go env
         run: export PATH=${PATH}:`go env GOPATH`/bin
       - name: deploy

--- a/.github/workflows/linux-amd64.yml
+++ b/.github/workflows/linux-amd64.yml
@@ -3,7 +3,7 @@ name: build linux-amd64
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
-on: [push,pull_request]
+on: workflow_dispatch
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,68 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Build
+  build-windows:
+    name: Build Windows (CGO)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Set up MinGW
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+          version: '8.1.0'
+      - name: Build Windows binaries
+        run: make windows-release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-binaries
+          path: "*.exe"
+
+  build-linux:
+    name: Build Linux (zig cc)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Install zig
+        run: |
+          curl -sSfL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | sudo tar -xJ --strip-components=1 -C /usr/local
+          sudo ln -sf /usr/local/zig /usr/local/bin/zig
+          zig version
+      - name: Build Linux
+        run: CC='zig cc -target x86_64-linux-gnu.2.17' make linux-action-amd64
+
+  release:
+    name: Release
+    if: github.event_name != 'pull_request'
+    needs: [build-windows, build-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false # <--- this
+          persist-credentials: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Download Windows binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-binaries
+      - name: Install zig
+        run: |
+          curl -sSfL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | sudo tar -xJ --strip-components=1 -C /usr/local
+          sudo ln -sf /usr/local/zig /usr/local/bin/zig
+          zig version
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
@@ -41,4 +90,3 @@ jobs:
           echo ${{ steps.semantic.outputs.new_release_major_version }}
           echo ${{ steps.semantic.outputs.new_release_minor_version }}
           echo ${{ steps.semantic.outputs.new_release_patch_version }}
-

--- a/.github/workflows/windows-amd64.yml
+++ b/.github/workflows/windows-amd64.yml
@@ -1,5 +1,5 @@
 name: build windows-amd64
-on: [push,pull_request]
+on: workflow_dispatch
 
 jobs:
   build_windows:

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ build/chain33-cli
 build/chain33.toml
 build/autotest/*
 !build/autotest/run.sh
+build/qt-*
 bityuan-*
+COMPAT.txt

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -9,7 +9,10 @@
     [
         "@semantic-release/release-notes-generator",
       {
-        "preset": "jshint"
+        "preset": "jshint",
+        "writerOpts": {
+          "footer": "\n\n---\n\n### 系统要求\n\n**Linux** (glibc >= 2.17): Ubuntu 18.04+, Debian 10+, CentOS 7+, RHEL 7+, Rocky 8+, Alma 8+\n\n**Windows**: Windows 10+, Windows Server 2016+\n"
+        }
       }
     ],
     [
@@ -55,7 +58,7 @@
     # "@semantic-release/github", #Default 4
     [
       "@semantic-release/github",
-      {"assets": ["build/*.tar.gz","build/*.zip"]}
+      {"assets": ["build/*.tar.gz","build/*.exe"]}
     ],
     [
       "@semantic-release/git",
@@ -66,7 +69,7 @@
     ],
     [
       "@semantic-release/exec", {
-      "prepareCmd": "make linux-action-amd64 VERSION=${nextRelease.version}"
+      "prepareCmd": "sudo apt-get install -y p7zip-full && CC='zig cc -target x86_64-linux-gnu.2.17' make linux-action-amd64 VERSION=${nextRelease.version} && make windows-qt-package PREV_RELEASE_TAG=$(gh release list -L 1 --json tagName --jq '.[0].tagName')"
     }
     ]
   ]

--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,65 @@ WINDOWS_ARCH_LIST = \
 	windows-amd64
 
 GOBUILD=CGO_ENABLED=1 go build $(BUILD_FLAGS)' -X "github.com/bityuan/bityuan/version.Version=$(VERSION)"  -w -s'
+GOBUILD_NOCGO=CGO_ENABLED=0 go build $(BUILD_FLAGS)' -X "github.com/bityuan/bityuan/version.Version=$(VERSION)"  -w -s'
 SRC_CLI := ./cli
 SRC := ./
 APP := bityuan
 CLI := bityuan-cli
 
 linux-action-amd64:
+	@echo "Linux x86_64 / glibc >= 2.17" > COMPAT.txt
+	@echo "Supports: Ubuntu 18.04+, Debian 10+, CentOS 7+, RHEL 7+, Rocky 8+, Alma 8+" >> COMPAT.txt
+	@echo "Alpine: use Docker or glibc compat layer" >> COMPAT.txt
 	GOARCH=amd64 GOOS=linux $(GOBUILD) -o $(APP)-linux-amd64 $(SRC)
 	GOARCH=amd64 GOOS=linux $(GOBUILD) -o $(CLI)-linux-amd64 $(SRC_CLI)
 	chmod +x $(APP)-linux-amd64 $(CLI)-linux-amd64
-	tar -zcvf build/$(APP)-linux-amd64.tar.gz $(APP)-linux-amd64  $(CLI)-linux-amd64 CHANGELOG.md bityuan-fullnode.toml bityuan.toml
+	tar -zcvf build/$(APP)-linux-amd64.tar.gz $(APP)-linux-amd64  $(CLI)-linux-amd64 CHANGELOG.md bityuan-fullnode.toml bityuan.toml COMPAT.txt
+
+windows-action-amd64:
+	GOARCH=amd64 GOOS=windows $(GOBUILD_NOCGO) -o $(APP)-windows-amd64.exe $(SRC)
+	GOARCH=amd64 GOOS=windows $(GOBUILD_NOCGO) -o $(CLI)-windows-amd64.exe $(SRC_CLI)
+	zip -j build/$(APP)-windows-amd64.zip $(APP)-windows-amd64.exe $(CLI)-windows-amd64.exe CHANGELOG.md bityuan-fullnode.toml bityuan.toml
+
+# CGO=1 native Windows build (used by release CI on windows runner)
+windows-release:
+	GOARCH=amd64 $(GOBUILD) -o $(APP)-windows-amd64.exe $(SRC)
+	GOARCH=amd64 $(GOBUILD) -o $(CLI)-windows-amd64.exe $(SRC_CLI)
+
+# Download the previous release's Windows package as template
+PREV_RELEASE_TAG ?= $(shell gh release list -L 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "v6.8.18")
+QT_PACKAGE_DIR := build/qt-package
+
+windows-qt-package:
+	@echo "Downloading previous release Windows package as template..."
+	@mkdir -p $(QT_PACKAGE_DIR)
+	@gh release download $(PREV_RELEASE_TAG) --pattern "*windows*" -D $(QT_PACKAGE_DIR) --clobber 2>/dev/null \
+		|| curl -sSfL "https://github.com/bityuan/bityuan/releases/download/$(PREV_RELEASE_TAG)/bityuan-windows-amd64-qt.exe" -o $(QT_PACKAGE_DIR)/prev-qt.exe 2>/dev/null \
+		|| (echo "WARNING: no previous Windows package found, skipping Qt wrap" && exit 0)
+	@# Extract previous installer
+	@if ls $(QT_PACKAGE_DIR)/*.exe 2>/dev/null | head -1 | grep -q .; then \
+		7z x $(QT_PACKAGE_DIR)/*.exe -o$(QT_PACKAGE_DIR)/extracted -y > /dev/null; \
+		rm -f $(QT_PACKAGE_DIR)/extracted/bityuan.exe \
+		      $(QT_PACKAGE_DIR)/extracted/bityuan-cli.exe \
+		      $(QT_PACKAGE_DIR)/extracted/bityuan-x86.exe \
+		      $(QT_PACKAGE_DIR)/extracted/bityuan-cli-x86.exe \
+		      $(QT_PACKAGE_DIR)/extracted/bityuan.toml \
+		      $(QT_PACKAGE_DIR)/extracted/bityuan-fullnode.toml \
+		      $(QT_PACKAGE_DIR)/extracted/grpc33.log; \
+		cp $(APP)-windows-amd64.exe $(QT_PACKAGE_DIR)/extracted/bityuan.exe; \
+		cp $(CLI)-windows-amd64.exe $(QT_PACKAGE_DIR)/extracted/bityuan-cli.exe; \
+		cp bityuan-fullnode.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
+		cp bityuan.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
+		cd $(QT_PACKAGE_DIR)/extracted && 7z a -mx9 ../bityuan.7z . > /dev/null; \
+		echo ';!@Install@!UTF-8!' > $(QT_PACKAGE_DIR)/sfx-config.txt; \
+		echo 'Title="BitYuan Wallet"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
+		echo 'ExecuteFile="bityuan-qt.exe"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
+		echo ';!@InstallEnd@!' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
+		cat /usr/lib/p7zip/7zS.sfx $(QT_PACKAGE_DIR)/sfx-config.txt $(QT_PACKAGE_DIR)/bityuan.7z > build/$(APP)-windows-amd64-qt.exe; \
+		chmod +x build/$(APP)-windows-amd64-qt.exe; \
+	else \
+		echo "No previous Windows package, skipping Qt wrap (raw .zip only)"; \
+	fi
 
 _GOBUILD := CGO_ENABLED=1 go build $(BUILD_FLAGS)' -w -s'
 linux-amd64:

--- a/golinter.sh
+++ b/golinter.sh
@@ -7,13 +7,11 @@ path="${2}"
 
 function filterLinter() {
     res=$(
-        golangci-lint run --no-config --issues-exit-code=1 --deadline=2m --disable-all \
+        golangci-lint run --no-config --issues-exit-code=1 --timeout=5m -j 1 --disable-all \
             --enable=gofmt \
             --enable=gosimple \
-            --enable=deadcode \
+            --enable=unused \
             --enable=unconvert \
-            --enable=varcheck \
-            --enable=structcheck \
             --enable=goimports \
             --enable=misspell \
             --exclude=underscores
@@ -26,17 +24,13 @@ function filterLinter() {
 
 function testLinter() {
     cd "${path}" >/dev/null || exit
-    golangci-lint run --no-config --issues-exit-code=1 --deadline=2m --disable-all \
+    golangci-lint run --no-config --issues-exit-code=1 --timeout=5m -j 1 --disable-all \
         --enable=gofmt \
         --enable=gosimple \
-        --enable=deadcode \
+        --enable=unused \
         --enable=unconvert \
-        --enable=interfacer \
-        --enable=varcheck \
-        --enable=structcheck \
         --enable=goimports \
         --enable=misspell \
-        --enable=golint \
         --exclude=underscores
 
     cd - >/dev/null || exit


### PR DESCRIPTION
Build and CI improvements only, no functional changes.

### Release
- Linux: zig cc targeting glibc 2.17 for broad compat (CentOS 7+, Ubuntu 18.04+)
- Windows: native CGO build on Windows runner via make, auto-wrap Qt installer from previous release
- Release notes include system requirements for both Linux and Windows

### CI fixes
- check_fmt: upgrade golangci-lint v1.44.2 → v1.55.2, replace deprecated linters, increase timeout
- check_fmt: add concurrency group and Go module cache to prevent OOM/cancel
- Upgrade deprecated GitHub Actions (checkout@v4, setup-go@v4, upload-artifact@v4)
- Disable windows-amd64 CI workflow (covered by release workflow)
- Fix findlargefile.sh to filter non-object entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)