### PR TITLE
[[FIX]] build and CI improvements only, no functional changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ windows-action-amd64:
 
 # CGO=1 native Windows build (used by release CI on windows runner)
 windows-release:
-	GOARCH=amd64 $(GOBUILD) -o $(APP)-windows-amd64.exe $(SRC)
-	GOARCH=amd64 $(GOBUILD) -o $(CLI)-windows-amd64.exe $(SRC_CLI)
+	GOARCH=amd64 $(_GOBUILD) -o $(APP)-windows-amd64.exe $(SRC)
+	GOARCH=amd64 $(_GOBUILD) -o $(CLI)-windows-amd64.exe $(SRC_CLI)
 
 # Download the previous release's Windows package as template
 PREV_RELEASE_TAG ?= $(shell gh release list -L 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "v6.8.18")

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ windows-qt-package:
 		cp $(CLI)-windows-amd64.exe $(QT_PACKAGE_DIR)/extracted/bityuan-cli.exe; \
 		cp bityuan-fullnode.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
 		cp bityuan.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
-		cd $(QT_PACKAGE_DIR)/extracted && 7z a -mx9 ../bityuan.7z . > /dev/null; \
+		7z a -mx9 $(QT_PACKAGE_DIR)/bityuan.7z $(QT_PACKAGE_DIR)/extracted/* > /dev/null; \
 		echo ';!@Install@!UTF-8!' > $(QT_PACKAGE_DIR)/sfx-config.txt; \
 		echo 'Title="BitYuan Wallet"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
 		echo 'ExecuteFile="bityuan-qt.exe"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \


### PR DESCRIPTION
Build and CI improvements only, no functional changes.

### Release
- Linux: zig cc targeting glibc 2.17 (CentOS 7+, Ubuntu 18.04+)
- Windows: CGO build on Windows runner, auto-wrap Qt installer from previous release
- PR verifies both Windows and Linux compile; push master triggers full release
- Release notes include system requirements for Linux and Windows

### CI fixes
- check_fmt: upgrade golangci-lint v1.44.2 → v1.55.2, replace deprecated linters
- check_fmt: add concurrency group and Go module cache
- Disable redundant linux-amd64 and windows-amd64 workflows
- Upgrade deprecated GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)