### PR TITLE
[[FIX]] windows Qt exe packaging, linux smoke test, CI improvements

### DIFF
--- a/.github/workflows/MacOS-amd64.yml
+++ b/.github/workflows/MacOS-amd64.yml
@@ -1,8 +1,5 @@
 name: build darwin-amd64
-on:
-  push:
-    branches: [ master ]
-  pull_request:
+on: workflow_dispatch
 
 jobs:
   build_macos:

--- a/.github/workflows/MacOS-amd64.yml
+++ b/.github/workflows/MacOS-amd64.yml
@@ -1,5 +1,8 @@
 name: build darwin-amd64
-on: [push,pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build_macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
-on: [push,pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,52 @@ jobs:
           version: '8.1.0'
       - name: Build Windows binaries
         run: make windows-release
+
+      - name: Smoke test
+        run: |
+          echo "Starting node..."
+          Start-Process -FilePath ".\bityuan-windows-amd64.exe" -NoNewWindow -PassThru | ForEach-Object {
+            for ($i=0; $i -lt 10; $i++) {
+              Start-Sleep 2
+              try {
+                $v = & .\bityuan-cli-windows-amd64.exe version 2>$null | ConvertFrom-Json
+                if ($v.title -eq 'bityuan' -and $v.app -match '^\d+\.\d+\.\d+' -and $v.chain33 -match '^\d+\.\d+\.\d+-\w+') {
+                  echo "OK: $($v | ConvertTo-Json -Compress)"
+                  break
+                }
+              } catch {}
+            }
+            Stop-Process -Id $_.Id -Force
+          }
+
+      - name: Package Qt installer
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          choco install 7zip -y 2>$null
+          Write-Host "Downloading Qt shell from v6.8.18..."
+          gh release download v6.8.18 --repo bityuan/bityuan --pattern "*windows*" --dir qt-shell --clobber
+          $shell = (Get-ChildItem qt-shell | Select-Object -First 1).FullName
+          Write-Host "Extracting $shell..."
+          7z x "$shell" -oqt-extracted -y
+          Remove-Item -Force qt-extracted/bityuan.exe,qt-extracted/bityuan-cli.exe,qt-extracted/bityuan-x86.exe,qt-extracted/bityuan-cli-x86.exe,qt-extracted/bityuan.toml,qt-extracted/bityuan-fullnode.toml,qt-extracted/grpc33.log -ErrorAction SilentlyContinue
+          Copy-Item bityuan-windows-amd64.exe qt-extracted/bityuan.exe
+          Copy-Item bityuan-cli-windows-amd64.exe qt-extracted/bityuan-cli.exe
+          Copy-Item bityuan.toml,bityuan-fullnode.toml qt-extracted/ -ErrorAction SilentlyContinue
+          cd qt-extracted; 7z a -sfx ..\bityuan-windows-amd64-qt.exe * -r
+          cd ..; Compress-Archive -Path bityuan-windows-amd64.exe,bityuan-cli-windows-amd64.exe,bityuan.toml,bityuan-fullnode.toml -DestinationPath bityuan-windows-amd64.zip
+
       - uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request'
+        with:
+          name: windows-qt-exe
+          path: bityuan-windows-amd64-qt.exe
+      - uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request'
         with:
           name: windows-binaries
-          path: "*.exe"
+          path: bityuan-windows-amd64.zip
 
   build-linux:
     name: Build Linux (zig cc)
@@ -45,6 +87,22 @@ jobs:
       - name: Build Linux
         run: CC='zig cc -target x86_64-linux-gnu.2.17' make linux-action-amd64
 
+      - name: Linux smoke test
+        run: |
+          echo "Starting node..."
+          ./bityuan-linux-amd64 > /tmp/smoke-node.log 2>&1 & NODE_PID=$!
+          for i in $(seq 1 25); do
+            sleep 2
+            RAW=$(./bityuan-cli-linux-amd64 version 2>/dev/null) && echo "$RAW" || true
+            V=$(echo "$RAW" | jq -r '.app // empty' 2>/dev/null) || true
+            if [ -n "$V" ]; then
+              echo "OK: $RAW"
+              break
+            fi
+          done
+          kill $NODE_PID 2>/dev/null; wait $NODE_PID 2>/dev/null
+          [ -n "$V" ] && echo "Smoke test OK" || { echo "FAIL"; exit 1; }
+
   release:
     name: Release
     if: github.event_name != 'pull_request'
@@ -60,10 +118,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - name: Download Windows binaries
+      - name: Download Windows Qt exe
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-qt-exe
+          path: build/
+      - name: Download Windows raw zip
         uses: actions/download-artifact@v4
         with:
           name: windows-binaries
+          path: build/
       - name: Install zig
         run: |
           curl -sSfL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | sudo tar -xJ --strip-components=1 -C /usr/local
@@ -83,10 +147,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Do something when a new release published
+      - name: Add footer and show version
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          echo ${{ steps.semantic.outputs.new_release_version }}
-          echo ${{ steps.semantic.outputs.new_release_major_version }}
-          echo ${{ steps.semantic.outputs.new_release_minor_version }}
-          echo ${{ steps.semantic.outputs.new_release_patch_version }}
+          V="${{ steps.semantic.outputs.new_release_version }}"
+          echo "Published: $V"
+          FOOTER="\n\n---\n\n### System Requirements\n\n**Linux**\n$(cat COMPAT.txt)\n\n**Windows**: Windows 10+, Windows Server 2016+"
+          BODY=$(gh release view "$V" --repo bityuan/bityuan --json body -q .body)
+          printf "%b" "$BODY$FOOTER" | gh release edit "$V" --repo bityuan/bityuan -F -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Build Windows binaries
         run: |
           $env:CGO_ENABLED = "1"
-          go build -ldflags "-s -w" -o bityuan.exe .
-          go build -ldflags "-s -w" -o bityuan-cli.exe ./cli
+          $gc = git rev-parse --short=8 HEAD
+          go build -ldflags "-s -w -X github.com/bityuan/bityuan/version.GitCommit=$gc -X github.com/33cn/chain33/common/version.GitCommit=$gc" -o bityuan.exe .
+          go build -ldflags "-s -w -X github.com/bityuan/bityuan/version.GitCommit=$gc -X github.com/33cn/chain33/common/version.GitCommit=$gc" -o bityuan-cli.exe ./cli
 
       - name: Smoke test
         run: |
@@ -35,8 +36,8 @@ jobs:
               Start-Sleep 2
               try {
                 $v = & .\bityuan-cli.exe version 2>$null | ConvertFrom-Json
-                if ($v.title -eq 'bityuan' -and $v.app -match '^\d+\.\d+\.\d+' -and $v.chain33 -match '^\d+\.\d+\.\d+-\w+') {
-                  echo "OK: $($v | ConvertTo-Json -Compress)"
+                if ($v.title -eq 'bityuan' -and $v.app -match '^\d+\.\d+\.\d+' -and $v.chain33 -match '^\d+\.\d+\.\d+') {
+                  Write-Host "OK: $($v | ConvertTo-Json -Compress)"
                   break
                 }
               } catch {}
@@ -83,8 +84,9 @@ jobs:
           cache: true
       - name: Build macOS
         run: |
-          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags '-s -w' -o bityuan .
-          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags '-s -w' -o bityuan-cli ./cli
+          GC=$(git rev-parse --short=8 HEAD)
+          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags "-s -w -X github.com/bityuan/bityuan/version.GitCommit=$GC -X github.com/33cn/chain33/common/version.GitCommit=$GC" -o bityuan .
+          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags "-s -w -X github.com/bityuan/bityuan/version.GitCommit=$GC -X github.com/33cn/chain33/common/version.GitCommit=$GC" -o bityuan-cli ./cli
           chmod +x bityuan bityuan-cli
           mkdir -p build
           tar -zcvf build/bityuan-darwin-${{ matrix.arch }}.tar.gz bityuan bityuan-cli bityuan.toml bityuan-fullnode.toml CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,8 @@ jobs:
     name: Build macOS (${{ matrix.arch }})
     strategy:
       matrix:
-        include:
-          - os: macos-13
-            arch: amd64
-          - os: macos-14
-            arch: arm64
-    runs-on: ${{ matrix.os }}
+        arch: [arm64, amd64]
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,19 @@ jobs:
           platform: x64
           version: '8.1.0'
       - name: Build Windows binaries
-        run: make windows-release
+        run: |
+          $env:CGO_ENABLED = "1"
+          go build -ldflags "-s -w" -o bityuan.exe .
+          go build -ldflags "-s -w" -o bityuan-cli.exe ./cli
 
       - name: Smoke test
         run: |
           echo "Starting node..."
-          Start-Process -FilePath ".\bityuan-windows-amd64.exe" -NoNewWindow -PassThru | ForEach-Object {
+          Start-Process -FilePath ".\bityuan.exe" -NoNewWindow -PassThru | ForEach-Object {
             for ($i=0; $i -lt 10; $i++) {
               Start-Sleep 2
               try {
-                $v = & .\bityuan-cli-windows-amd64.exe version 2>$null | ConvertFrom-Json
+                $v = & .\bityuan-cli.exe version 2>$null | ConvertFrom-Json
                 if ($v.title -eq 'bityuan' -and $v.app -match '^\d+\.\d+\.\d+' -and $v.chain33 -match '^\d+\.\d+\.\d+-\w+') {
                   echo "OK: $($v | ConvertTo-Json -Compress)"
                   break
@@ -42,7 +45,6 @@ jobs:
           }
 
       - name: Package Qt installer
-        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -53,22 +55,47 @@ jobs:
           Write-Host "Extracting $shell..."
           7z x "$shell" -oqt-extracted -y
           Remove-Item -Force qt-extracted/bityuan.exe,qt-extracted/bityuan-cli.exe,qt-extracted/bityuan-x86.exe,qt-extracted/bityuan-cli-x86.exe,qt-extracted/bityuan.toml,qt-extracted/bityuan-fullnode.toml,qt-extracted/grpc33.log -ErrorAction SilentlyContinue
-          Copy-Item bityuan-windows-amd64.exe qt-extracted/bityuan.exe
-          Copy-Item bityuan-cli-windows-amd64.exe qt-extracted/bityuan-cli.exe
-          Copy-Item bityuan.toml,bityuan-fullnode.toml qt-extracted/ -ErrorAction SilentlyContinue
+          Copy-Item bityuan.exe,bityuan-cli.exe,bityuan.toml,bityuan-fullnode.toml qt-extracted/ -ErrorAction SilentlyContinue
           cd qt-extracted; 7z a -sfx ..\bityuan-windows-amd64-qt.exe * -r
-          cd ..; Compress-Archive -Path bityuan-windows-amd64.exe,bityuan-cli-windows-amd64.exe,bityuan.toml,bityuan-fullnode.toml -DestinationPath bityuan-windows-amd64.zip
+          cd ..
+          Compress-Archive -Path bityuan.exe,bityuan-cli.exe,bityuan.toml,bityuan-fullnode.toml -DestinationPath bityuan-windows-amd64.zip
 
       - uses: actions/upload-artifact@v4
-        if: github.event_name != 'pull_request'
         with:
           name: windows-qt-exe
           path: bityuan-windows-amd64-qt.exe
       - uses: actions/upload-artifact@v4
-        if: github.event_name != 'pull_request'
         with:
           name: windows-binaries
           path: bityuan-windows-amd64.zip
+
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+            arch: amd64
+          - os: macos-14
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Build macOS
+        run: |
+          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags '-s -w' -o bityuan .
+          CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags '-s -w' -o bityuan-cli ./cli
+          chmod +x bityuan bityuan-cli
+          mkdir -p build
+          tar -zcvf build/bityuan-darwin-${{ matrix.arch }}.tar.gz bityuan bityuan-cli bityuan.toml bityuan-fullnode.toml CHANGELOG.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: darwin-${{ matrix.arch }}
+          path: build/bityuan-darwin-${{ matrix.arch }}.tar.gz
 
   build-linux:
     name: Build Linux (zig cc)
@@ -106,7 +133,7 @@ jobs:
   release:
     name: Release
     if: github.event_name != 'pull_request'
-    needs: [build-windows, build-linux]
+    needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -127,6 +154,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-binaries
+          path: build/
+      - name: Download macOS amd64
+        uses: actions/download-artifact@v4
+        with:
+          name: darwin-amd64
+          path: build/
+      - name: Download macOS arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: darwin-arm64
           path: build/
       - name: Install zig
         run: |

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -37,7 +37,7 @@
     # "@semantic-release/github", #Default 4
     [
       "@semantic-release/github",
-      {"assets": ["build/*.tar.gz","build/*.exe"]}
+      {"assets": ["build/*.tar.gz","build/*.exe","build/*.zip"]}
     ],
     [
       "@semantic-release/git",
@@ -48,8 +48,7 @@
     ],
     [
       "@semantic-release/exec", {
-      "prepareCmd": "sudo apt-get install -y p7zip-full && CC='zig cc -target x86_64-linux-gnu.2.17' make linux-action-amd64 VERSION=${nextRelease.version} && make windows-qt-package PREV_RELEASE_TAG=$(gh release list -L 1 --json tagName --jq '.[0].tagName')",
-      "successCmd": "gh release edit ${nextRelease.tag} --repo bityuan/bityuan --notes \"$(gh release view ${nextRelease.tag} --repo bityuan/bityuan --json body -q .body)\n\n---\n\n### System Requirements\n\n**Linux** (glibc >= 2.17): Ubuntu 18.04+, Debian 10+, CentOS 7+, RHEL 7+, Rocky 8+, Alma 8+\n\n**Windows**: Windows 10+, Windows Server 2016+\""
+      "prepareCmd": "CC='zig cc -target x86_64-linux-gnu.2.17' make linux-action-amd64 VERSION=${nextRelease.version}"
     }
     ]
   ]

--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,19 @@ windows-release:
 	GOARCH=amd64 $(_GOBUILD) -o $(CLI)-windows-amd64.exe $(SRC_CLI)
 
 # Download the previous release's Windows package as template
-PREV_RELEASE_TAG ?= $(shell gh release list -L 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "v6.8.18")
+PREV_RELEASE_TAG ?= v6.8.18
 QT_PACKAGE_DIR := build/qt-package
 
 windows-qt-package:
 	@echo "Downloading previous release Windows package as template..."
 	@mkdir -p $(QT_PACKAGE_DIR)
-	@gh release download $(PREV_RELEASE_TAG) --pattern "*windows*" -D $(QT_PACKAGE_DIR) --clobber 2>/dev/null \
-		|| curl -sSfL "https://github.com/bityuan/bityuan/releases/download/$(PREV_RELEASE_TAG)/bityuan-windows-amd64-qt.exe" -o $(QT_PACKAGE_DIR)/prev-qt.exe 2>/dev/null \
-		|| (echo "WARNING: no previous Windows package found, skipping Qt wrap" && exit 0)
+	@curl -sSL -o $(QT_PACKAGE_DIR)/prev-qt.zip "https://github.com/bityuan/bityuan/releases/download/$(PREV_RELEASE_TAG)/bityuan-windows-amd64-qt.zip"; \
+	if [ ! -f $(QT_PACKAGE_DIR)/prev-qt.zip ]; then \
+		echo "WARNING: no previous Windows package found, skipping Qt wrap"; exit 0; \
+	fi
 	@# Extract previous installer
-	@if ls $(QT_PACKAGE_DIR)/*.exe 2>/dev/null | head -1 | grep -q .; then \
-		7z x $(QT_PACKAGE_DIR)/*.exe -o$(QT_PACKAGE_DIR)/extracted -y > /dev/null; \
+	@if ls $(QT_PACKAGE_DIR)/* 2>/dev/null | head -1 | grep -q .; then \
+		7z x $(QT_PACKAGE_DIR)/* -o$(QT_PACKAGE_DIR)/extracted -y > /dev/null; \
 		rm -f $(QT_PACKAGE_DIR)/extracted/bityuan.exe \
 		      $(QT_PACKAGE_DIR)/extracted/bityuan-cli.exe \
 		      $(QT_PACKAGE_DIR)/extracted/bityuan-x86.exe \
@@ -80,15 +81,10 @@ windows-qt-package:
 		cp $(CLI)-windows-amd64.exe $(QT_PACKAGE_DIR)/extracted/bityuan-cli.exe; \
 		cp bityuan-fullnode.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
 		cp bityuan.toml $(QT_PACKAGE_DIR)/extracted/ 2>/dev/null || true; \
-		( cd $(QT_PACKAGE_DIR)/extracted && 7z a -mx9 ../bityuan.7z . > /dev/null ); \
-		echo ';!@Install@!UTF-8!' > $(QT_PACKAGE_DIR)/sfx-config.txt; \
-		echo 'Title="BitYuan Wallet"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
-		echo 'ExecuteFile="bityuan-qt.exe"' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
-		echo ';!@InstallEnd@!' >> $(QT_PACKAGE_DIR)/sfx-config.txt; \
-		cat /usr/lib/p7zip/7zS.sfx $(QT_PACKAGE_DIR)/sfx-config.txt $(QT_PACKAGE_DIR)/bityuan.7z > build/$(APP)-windows-amd64-qt.exe; \
-		chmod +x build/$(APP)-windows-amd64-qt.exe; \
+		cd $(QT_PACKAGE_DIR)/extracted && zip -r ../../build/$(APP)-windows-amd64-qt.zip . > /dev/null; \
 	else \
-		echo "No previous Windows package, skipping Qt wrap (raw .zip only)"; \
+		echo "No previous Windows package, creating raw .zip"; \
+		zip -j build/$(APP)-windows-amd64-qt.zip $(APP)-windows-amd64.exe $(CLI)-windows-amd64.exe bityuan.toml bityuan-fullnode.toml; \
 	fi
 
 _GOBUILD := CGO_ENABLED=1 go build $(BUILD_FLAGS)' -w -s'


### PR DESCRIPTION
### Release
- Windows: Qt installer (.exe) packaged on Windows runner with native 7z SFX
- Windows: raw binary zip also included in release
- Release assets: tar.gz + exe + zip

### Smoke Tests
- Linux: start node + CLI version check (jq)
- Windows: start node + CLI version validation

### CI
- build.yml, MacOS-amd64.yml: only trigger on push master and PR
- Release workflow: build-windows + build-linux parallel, release waits for both